### PR TITLE
RTC: FD-76326: Load Gutenberg JS/CSS only when the field is used

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,15 +4,6 @@ After:
   - '#corefieldtypes'
 ---
 
-# Configure Admin Extensions:
-
-SilverStripe\Admin\LeftAndMain:
-  extra_requirements_css:
-    - "mademedia/silverstripe-gutenberg-editor: client/dist/style.css"
-  extra_requirements_javascript:
-    - "mademedia/silverstripe-gutenberg-editor: client/dist/globals.js"
-    - "mademedia/silverstripe-gutenberg-editor: client/dist/bundle.js"
-
 SilverStripe\Core\Injector\Injector:
   GutenbergText:
     class: MadeHQ\Gutenberg\FieldTypes\DBGutenbergText

--- a/src/Forms/GutenbergEditorField.php
+++ b/src/Forms/GutenbergEditorField.php
@@ -4,9 +4,23 @@ namespace MadeHQ\Gutenberg\Forms;
 
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\Core\Convert;
+use SilverStripe\View\Requirements;
 
 class GutenbergEditorField extends TextareaField
 {
+    /**
+     *
+     */
+    public function Field($properties = array())
+    {
+        Requirements::css('mademedia/silverstripe-gutenberg-editor: client/dist/style.css');
+
+        Requirements::javascript('mademedia/silverstripe-gutenberg-editor: client/dist/globals.js');
+        Requirements::javascript('mademedia/silverstripe-gutenberg-editor: client/dist/bundle.js');
+
+        return parent::Field($properties);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
This means that if only a HTMLEditor is on the page then it will load

Requires a refresh on the page but its a step in the right direction